### PR TITLE
fix: add --no-emit-project to `uv export`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,10 +56,10 @@ log "Install uv Python version"
 uv python install 2>&1 | indent
 
 log "Export $REQUIREMENTS_FILE from uv"
-uv export --output-file "$REQUIREMENTS_FILE" --no-dev --frozen 2>&1 | indent
+uv export --output-file "$REQUIREMENTS_FILE" --no-dev --no-emit-project --frozen 2>&1 | indent
 
 log "Export $REQUIREMENTS_TEST_FILE from uv (for Heroku CI)"
-uv export --output-file "$REQUIREMENTS_TEST_FILE" --frozen 2>&1 | indent
+uv export --output-file "$REQUIREMENTS_TEST_FILE" --no-emit-project --frozen 2>&1 | indent
 
 if [ -f "$RUNTIME_FILE" ] ; then
     log "$RUNTIME_FILE found, skipping $RUNTIME_FILE generation" >&2


### PR DESCRIPTION
This causes an issue with Heroku because by default it will generate the line `-e .` in the `requirements.txt`, resulting in the following error:

```
ERROR: The editable requirement file:///tmp/build_6e1bb93c (from -r requirements.txt (line 2)) cannot be installed when requiring hashes, because there is no single file to hash.
```

I'm curious to understand how it worked for you (and if we did something wrong), as the error seems unavoidable.